### PR TITLE
Expose Smocks.profile to Midway object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,8 @@ var midwayInstance = module.exports = {
     return MetricManager.isMetricsEnabled();
   },
 
+  profile: Smocks.profile,
+
   util: Utils,
   log: Logger
 };


### PR DESCRIPTION
### Problem

I can't save a profile "for everyone" through midway


![image](https://user-images.githubusercontent.com/3091143/55341890-1e6ae080-546d-11e9-9350-6fbcac2b35d5.png)

Midway says 

>  "Copy and paste to your smocks setup code to save the profile"

While Midway docs are excellent, especially the [training guide](http://testarmada.io/documentation/Mocking/Native%20Android/JAVASCRIPT/Training%20Guide/), I don't see any mention on how to deal with profile sharing specific to Midway.  It seems to all be specific to Smocks which would be fine if I have access to `Smocks.profile` from Midway. 

### Solution

I expose `Smocks.profile` as `Midway.profile` and can write the following code snippet

```js
const midway = require('testarmada-midway');

midway.profile('My custom profile', {
  'GET /some/endpoint': { activeVariant: 'Alternative variant' },
});
```

and now I can see the profile available for everyone

![image](https://user-images.githubusercontent.com/3091143/55343319-76571680-5470-11e9-8728-339135e0f047.png)
